### PR TITLE
Add export of UXAS_BUILD_DIR and UXAS_SOURCE_DIR

### DIFF
--- a/anod-build
+++ b/anod-build
@@ -82,6 +82,7 @@ class UxasBuildJob(UxasJob):
             mkdir(self.data.anod_instance.build_space.install_dir)
             Env().store()
             cd(self.data.anod_instance.build_space.build_dir)
+            self.data.anod_instance.jobs = Env().build.cpu.cores
             self.data.anod_instance.build()
             Env().restore()
             self.run_status = ReturnValue.success

--- a/specs/uxas.anod
+++ b/specs/uxas.anod
@@ -44,6 +44,12 @@ class Uxas(spec('common')):
 
     def setenv(self):
         self.env.add_path(os.path.join(self.build_space.install_dir, 'bin'))
+        if self.scenario == 'gcov':
+            # The two environment variables are used by the testsuite to locate
+            # sources and objects used by this uxas build. The testsuite used
+            # this directories to compute coverage summaries.
+            os.environ['UXAS_BUILD_DIR'] = self.build_space.build_dir
+            os.environ['UXAS_SOURCE_DIR'] = self.build_space.src_dir
 
     def build_setenv(self):
         self.deps['zeromq'].setenv(shared=False)


### PR DESCRIPTION
The variables are set when compiling uxas with the gcov mode. They
are used by the testsuite to locate objects and sources during coverage
information processing.