### PR TITLE
Fix banner typo and location in anod-setenv

### DIFF
--- a/anod-setenv
+++ b/anod-setenv
@@ -35,16 +35,16 @@ def check_tool(tool):
 
 # Help users who can't remember to use eval.
 BANNER = '''
+
 # ----------------------------------------------------------------------------
-# If you're seeing this, then you forgot eval!
+# If you are seeing this, then you forgot eval.
 #
-# You need to run anot-setenv like this:
+# You need to run anod-setenv like this:
 #
 #   eval `./anod-setenv uxas`
 #
 # Otherwise, no changes will be made to your environment.
 # ----------------------------------------------------------------------------
-
 '''
 
 if __name__ == '__main__':
@@ -97,8 +97,9 @@ if __name__ == '__main__':
         if hasattr(anod_instance, 'setenv'):
             anod_instance.setenv()
 
-    print(BANNER)
-
     for var, value in os.environ.items():
         if var not in saved_env or saved_env[var] != os.environ[var]:
             print('export %s="%s"' % (var, value))
+
+    print(BANNER)
+    


### PR DESCRIPTION
Typo in message.
Banner cannot be before the commands (or eval doesn't evaluate them).