### PR TITLE
Enhance run-example.

### DIFF
--- a/install/run-example-completion.bash
+++ b/install/run-example-completion.bash
@@ -11,7 +11,12 @@ else
 fi
 
 _run_example_completions() {
-  COMPREPLY=( $( compgen -W "$( ${INSTALL_DIR}/../run-example --list )" -- "${COMP_WORDS[1]}" ) )
+  _OPTIONS="$( ${INSTALL_DIR}/../run-example --complete-options )"
+  if [ $? != 0 ]; then
+    COMPREPLY=("Autocomplete not available; build OpenUxAS using \`./anod build uxas\`" " ")
+  else
+    COMPREPLY=( $( compgen -W "${_OPTIONS}" -- "${COMP_WORDS[1]}" ) )
+  fi
 }
 
 complete -F _run_example_completions run-example

--- a/run-example
+++ b/run-example
@@ -2,6 +2,21 @@
 
 ROOT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 
+if [ $1 == "--complete-options" ]; then
+    # Need to be able to find run-example, which will be in the src dir that
+    # this sets.
+    eval "$( "${ROOT_DIR}"/anod printenv uxas )"
+
+    # Is it there?
+    if [ ! -f "${UXAS_SOURCE_DIR}/run-example" ]; then
+        echo "You must build OpenUxAS first, using \`./anod build uxas\`"
+        exit 1
+    fi
+
+    "${UXAS_SOURCE_DIR}/run-example" --complete-options
+    exit 0
+fi
+
 # First, let's set up our environment.
 eval "$( "${ROOT_DIR}"/anod printenv uxas )"
 eval "$( "${ROOT_DIR}"/anod printenv uxas-ada )"
@@ -9,12 +24,12 @@ eval "$( "${ROOT_DIR}"/anod printenv amase )"
 
 # Now, as a sanity check, let's make sure that uxas and amase have been built.
 if [ ! -f "${UXAS_INSTALL_DIR}"/bin/uxas ]; then
-    echo "You need to build OpenUxAS first, using \`./anod-build uxas\`"
+    echo "You need to build OpenUxAS first, using \`./anod build uxas\`"
     exit 1
 fi
 
 if [ ! -f "${AMASE_SOURCE_DIR}"/OpenAMASE/build/classes/MakeDistribution.class ]; then
-    echo "You need to build OpenAMASE first, using \`./anod-build amase\`"
+    echo "You need to build OpenAMASE first, using \`./anod build amase\`"
     exit 2
 fi
 


### PR DESCRIPTION
* support the --complete-options argument by simplifying requirements
  for run-example and not printing extraneous output.
* enhance the autocomplete script by creating a synthetic list of
  completions to report errors (like not having built OpenUxAS).

This depends upon https://github.com/AdaCore/OpenUxAS/pull/3 (so that should be merged first)